### PR TITLE
Add recipientsID and check in validation

### DIFF
--- a/java/src/main/java/de/tu_darmstadt/cbs/emailsmpc/AppModel.java
+++ b/java/src/main/java/de/tu_darmstadt/cbs/emailsmpc/AppModel.java
@@ -512,7 +512,7 @@ public class AppModel implements Serializable, Cloneable {
         if (!(state == AppState.RECIEVING_SHARE || state == AppState.RECIEVING_RESULT))
             throw new IllegalStateException("Setting a share from a Message is not allowed at state " + state);
         if(!msg.recipientName.equals(getParticipantFromId(ownId).name) || !msg.recipientEmailAddress.equals(getParticipantFromId(ownId).emailAddress)){
-            throw new IllegalArgumentException("Message recipient is not participant in current appmodel");
+            throw new IllegalArgumentException("Message recipient is not the participant in current appmodel");
         }
         if (Message.validateData(getParticipantId(sender), participants[ownId], msg.data)) {
             if (state == AppState.RECIEVING_SHARE) {


### PR DESCRIPTION
I found the following bug: When a message to a wrong participient is entered the UI gets blocked.
This nirmally should never happen, since it would mean a user recieved a message which was not intended for them.
However, I still needed a fix. Please find a suggestion  in the PR.
Testing for these code changes has not been finished yet.