### PR TITLE
Bug fix: Load moved files

### DIFF
--- a/java/src/main/java/de/tu_darmstadt/cbs/emailsmpc/AppModel.java
+++ b/java/src/main/java/de/tu_darmstadt/cbs/emailsmpc/AppModel.java
@@ -82,7 +82,7 @@ public class AppModel implements Serializable, Cloneable {
     private Message[] unsentMessages;
 
     /** The filename. */
-    public File filename;
+    public transient File filename;
 
     /**
      * Instantiates a new app model.


### PR DESCRIPTION
When loading a file, which has been in another path when saving, the old file path is kept. A new save would therefore be done in the old path.
I am, however, not sure why this bug is revealed now and not before...