### PR TITLE
Bug synchronized

### DIFF
--- a/src/main/java/org/bihealth/mi/easybus/implementations/email/ConnectionIMAP.java
+++ b/src/main/java/org/bihealth/mi/easybus/implementations/email/ConnectionIMAP.java
@@ -114,7 +114,7 @@ public class ConnectionIMAP extends ConnectionEmail {
     }
 
     @Override
-    protected synchronized List<ConnectionEmailMessage> list() throws BusException {
+    protected List<ConnectionEmailMessage> list() throws BusException {
         
         // Make sure we are ready to go
         Folder folder = null;


### PR DESCRIPTION
For now we have a bug, that sending e-mails takes a long time (ca. 30 seconds).
I think the issue is that the methods ConnectionIMAP.list(...) and ConnectionIMAP.send(...) both have the synchronized keyword and since they are called from two different threads they share the same lock.
(see also https://stackoverflow.com/questions/15438727/if-i-synchronized-two-methods-on-the-same-class-can-they-run-simultaneously/15438792).

Maybe a solution is to set synchronized instead of lis() to the list-calling method receive().